### PR TITLE
Patch CSS & boost qwebr to release

### DIFF
--- a/slides/04-logistic/_extensions/coatless/webr/_extension.yml
+++ b/slides/04-logistic/_extensions/coatless/webr/_extension.yml
@@ -1,7 +1,7 @@
 name: webr
 title: Embedded webr code cells
 author: James Joseph Balamuta
-version: 0.4.0-dev.8
+version: 0.4.0
 quarto-required: ">=1.2.198"
 contributes:
   filters:

--- a/slides/04-logistic/_extensions/coatless/webr/qwebr-monaco-editor-element.js
+++ b/slides/04-logistic/_extensions/coatless/webr/qwebr-monaco-editor-element.js
@@ -146,13 +146,10 @@ globalThis.qwebrCreateMonacoEditorInstance = function (cellData) {
 
   // Add a click event listener to the reset button
   copyButton.onclick = function () {
-    // Ensure the editor is in focus
-    editor.focus();
-
-    // Retrieve data
+    // Retrieve current code data
     const data = editor.getValue();
     
-    // Set the clipboard contents.
+    // Write code data onto the clipboard.
     navigator.clipboard.writeText(data || "");
   };
   

--- a/slides/04-logistic/_extensions/coatless/webr/webr.lua
+++ b/slides/04-logistic/_extensions/coatless/webr/webr.lua
@@ -64,6 +64,7 @@ local qwebRDefaultCellOptions = {
   ["output"] = "true",
   ["comment"] = "",
   ["label"] = "",
+  ["autorun"] = "",
   ["classes"] = "",
   ["dpi"] = 72,
   ["fig-cap"] = "",
@@ -528,7 +529,7 @@ local function enableWebRCodeCell(el)
   
   -- Verify the element has attributes and the document type is HTML
   -- not sure if this will work with an epub (may need html:js)
-  if not (el.attr and quarto.doc.is_format("html")) then
+  if not (el.attr and (quarto.doc.is_format("html") or quarto.doc.is_format("markdown"))) then
     return el
   end
 
@@ -567,6 +568,14 @@ local function enableWebRCodeCell(el)
   -- Ensure we have a label representation
   if cellOptions["label"] == '' then
     cellOptions["label"] = "unnamed-chunk-" .. qwebrCounter
+  end
+  -- Set autorun to false if interactive
+  if cellOptions["autorun"] == "" then
+    if cellOptions["context"] == "interactive" then
+      cellOptions["autorun"] = "false"
+    else
+      cellOptions["autorun"] = "true"
+    end
   end
 
   -- Remove space left between options and code contents

--- a/slides/04-logistic/slide-style.css
+++ b/slides/04-logistic/slide-style.css
@@ -30,9 +30,8 @@ div.cell-output cell-output-stdout {
     max-height: 800px;
 }
 
-.qwebr-output-code-area {
-   background-color: red
+.reveal div.qwebr-output-code-area pre {
+   background-color: red;
 }
-
 
 


### PR DESCRIPTION
Unfortunately, `revealjs` has its own `pre` tag styling in `.reveal pre` that was preventing a direct use of `.qwebr-output-code-area`. So, I've tailored a more specific nesting rule.

I also bumped up the version of webR to the release candidate that includes `autorun: true`.